### PR TITLE
Remove unnecessary description & keywords fields from package.json files

### DIFF
--- a/react-utility-types/Exercise1/problem/package.json
+++ b/react-utility-types/Exercise1/problem/package.json
@@ -1,12 +1,6 @@
 {
   "name": "react-utility-types",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [
-    "typescript",
-    "react",
-    "starter"
-  ],
   "main": "index.tsx",
   "dependencies": {
     "react": "17.0.2",

--- a/react-utility-types/Exercise1/solution/package.json
+++ b/react-utility-types/Exercise1/solution/package.json
@@ -1,12 +1,6 @@
 {
   "name": "react-utility-types",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [
-    "typescript",
-    "react",
-    "starter"
-  ],
   "main": "index.tsx",
   "dependencies": {
     "react": "17.0.2",

--- a/typing-react-components/Exercise1/problem/package.json
+++ b/typing-react-components/Exercise1/problem/package.json
@@ -1,12 +1,6 @@
 {
   "name": "typing-react-components",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [
-    "typescript",
-    "react",
-    "starter"
-  ],
   "main": "index.tsx",
   "dependencies": {
     "react": "17.0.2",

--- a/typing-react-events/Exercise1/problem/package.json
+++ b/typing-react-events/Exercise1/problem/package.json
@@ -1,12 +1,6 @@
 {
   "name": "typing-react-events",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [
-    "typescript",
-    "react",
-    "starter"
-  ],
   "main": "index.tsx",
   "dependencies": {
     "react": "17.0.2",

--- a/typing-react-events/Exercise1/solution/package.json
+++ b/typing-react-events/Exercise1/solution/package.json
@@ -1,12 +1,6 @@
 {
   "name": "typing-react-events",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [
-    "typescript",
-    "react",
-    "starter"
-  ],
   "main": "index.tsx",
   "dependencies": {
     "react": "17.0.2",

--- a/typing-react-state/Exercise1/problem/package.json
+++ b/typing-react-state/Exercise1/problem/package.json
@@ -1,12 +1,6 @@
 {
   "name": "typing-react-state",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [
-    "typescript",
-    "react",
-    "starter"
-  ],
   "main": "index.tsx",
   "dependencies": {
     "react": "17.0.2",

--- a/typing-react-state/Exercise1/solution/package.json
+++ b/typing-react-state/Exercise1/solution/package.json
@@ -1,12 +1,6 @@
 {
   "name": "typing-react-state",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [
-    "typescript",
-    "react",
-    "starter"
-  ],
   "main": "index.tsx",
   "dependencies": {
     "react": "17.0.2",

--- a/typing-react-state/Exercise2/problem/package.json
+++ b/typing-react-state/Exercise2/problem/package.json
@@ -1,12 +1,6 @@
 {
   "name": "typing-react-state",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [
-    "typescript",
-    "react",
-    "starter"
-  ],
   "main": "index.tsx",
   "dependencies": {
     "react": "17.0.2",

--- a/typing-react-state/Exercise2/solution/package.json
+++ b/typing-react-state/Exercise2/solution/package.json
@@ -1,12 +1,6 @@
 {
   "name": "typing-react-state",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [
-    "typescript",
-    "react",
-    "starter"
-  ],
   "main": "index.tsx",
   "dependencies": {
     "react": "17.0.2",

--- a/typing-react-state/Exercise3/problem/package.json
+++ b/typing-react-state/Exercise3/problem/package.json
@@ -1,12 +1,6 @@
 {
   "name": "typing-react-state",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [
-    "typescript",
-    "react",
-    "starter"
-  ],
   "main": "index.tsx",
   "dependencies": {
     "react": "17.0.2",

--- a/typing-react-state/Exercise3/solution/package.json
+++ b/typing-react-state/Exercise3/solution/package.json
@@ -1,12 +1,6 @@
 {
   "name": "typing-react-state",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [
-    "typescript",
-    "react",
-    "starter"
-  ],
   "main": "index.tsx",
   "dependencies": {
     "react": "17.0.2",

--- a/unit-testing-react-what-why-how/vehicle-selector-react/package.json
+++ b/unit-testing-react-what-why-how/vehicle-selector-react/package.json
@@ -1,8 +1,6 @@
 {
   "name": "testing-with-jest",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [],
   "main": "src/index.js",
   "dependencies": {
     "@testing-library/react": "9.4.0",

--- a/ux-of-data-fetching/Exercise1/problem-backup/package.json
+++ b/ux-of-data-fetching/Exercise1/problem-backup/package.json
@@ -1,8 +1,6 @@
 {
   "name": "ux-of-data-fetching-training",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [],
   "main": "src/index.js",
   "dependencies": {
     "@testing-library/jest-dom": "5.16.4",

--- a/ux-of-data-fetching/Exercise1/problem/package.json
+++ b/ux-of-data-fetching/Exercise1/problem/package.json
@@ -1,8 +1,6 @@
 {
   "name": "ux-of-data-fetching-training",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [],
   "main": "src/index.js",
   "dependencies": {
     "@testing-library/jest-dom": "5.16.4",

--- a/ux-of-data-fetching/Exercise1/solution/package.json
+++ b/ux-of-data-fetching/Exercise1/solution/package.json
@@ -1,8 +1,6 @@
 {
   "name": "ux-of-data-fetching-training",
   "version": "1.0.0",
-  "description": "",
-  "keywords": [],
   "main": "src/index.js",
   "dependencies": {
     "@testing-library/jest-dom": "5.16.4",


### PR DESCRIPTION
These aren’t necessary because we aren’t publishing to npm.