### PR TITLE
Remove unnecessary browserslist field from package.json files

### DIFF
--- a/unit-testing-react-what-why-how/vehicle-selector-react/package.json
+++ b/unit-testing-react-what-why-how/vehicle-selector-react/package.json
@@ -19,11 +19,5 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
-  },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all"
-  ]
+  }
 }

--- a/ux-of-data-fetching/Exercise1/problem-backup/package.json
+++ b/ux-of-data-fetching/Exercise1/problem-backup/package.json
@@ -22,11 +22,5 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
-  },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all"
-  ]
+  }
 }

--- a/ux-of-data-fetching/Exercise1/problem/package.json
+++ b/ux-of-data-fetching/Exercise1/problem/package.json
@@ -24,12 +24,6 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all"
-  ],
   "msw": {
     "workerDirectory": "public"
   }

--- a/ux-of-data-fetching/Exercise1/solution/package.json
+++ b/ux-of-data-fetching/Exercise1/solution/package.json
@@ -24,12 +24,6 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all"
-  ],
   "msw": {
     "workerDirectory": "public"
   }


### PR DESCRIPTION
These aren’t necessary because we aren’t relying on Babel to transpile for old browsers.