### PR TITLE
Improve the third “Typing React State” exercise

### DIFF
--- a/typing-react-state/Exercise3/problem/src/App.tsx
+++ b/typing-react-state/Exercise3/problem/src/App.tsx
@@ -1,56 +1,69 @@
-// Make changes to the useRefs in order to correct TS errors
-// Take note of the state's structure while adding types.
-// Bonus question - What happens if we use useState
-// instead of useRef?
+/*
 
-import React, { useRef, useState } from "react";
+Exercise:
+
+1) Add types to all of the local state variables.
+2) Fix the type for `previousFullName` so it is mutable.
+
+Bonus question: what happens if we replace useRef with useState?
+
+*/
+
+import React, { FormEvent, useRef, useState } from "react";
 
 const App = () => {
-  const [fullName, setFullName] = useState("");
+  const firstNameRef = useRef();
+  const [firstNameValue, setFirstNameValue] = useState();
 
-  const firstNameRef = useRef<string>(null);
-  const lastNameRef = useRef({});
+  const lastNameRef = useRef();
+  const [lastNameValue, setLastNameValue] = useState();
 
-  const handleFirstNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const firstName = e.target.value;
-    firstNameRef.current = firstName
-      ? firstName.charAt(0).toUpperCase() + firstName.slice(1)
-      : null;
-    // Cannot assign to 'current' because it is a read-only property.
-  };
+  const previousFullName = useRef<string>(null);
 
-  const handleLastNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const lastName = e.target.value;
-    lastNameRef.current.lastName = lastName
-      ? lastName.charAt(0).toUpperCase() + lastName.slice(1)
-      : "";
-    // Property 'lastName' does not exist on type '{}'.
-  };
+  const fullName = firstNameValue && lastNameValue ? `${firstNameValue} ${lastNameValue}` : "";
 
-  const showFullNameClick = () => {
-    const fullName =
-      firstNameRef.current && lastNameRef.current.lastName
-        ? `${firstNameRef.current} ${lastNameRef.current.lastName}`
-        : "Incomplete Name";
-    // Property 'lastName' does not exist on type '{}'.
-    setFullName(fullName);
-  };
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+
+    // Give focus to the first input element that isn’t valid
+    if (firstNameRef.current && firstNameRef.current.checkValidity() === false) {
+      firstNameRef.current.focus();
+    } else if (lastNameRef.current && lastNameRef.current.checkValidity() === false) {
+      lastNameRef.current.focus();
+    }
+
+    // Let the user know they’ve updated the full name
+    if (previousFullName.current !== fullName) {
+      if (fullName) {
+        alert(`Update full name from “${previousFullName.current || ""}” to “${fullName}”`);
+      }
+      previousFullName.current = fullName;
+    }
+  }
 
   return (
-    <>
-      <div>
-        First Name:
-        <input onChange={handleFirstNameChange} />
-      </div>
-      <div>
-        Last Name:
-        <input onChange={handleLastNameChange} />
-      </div>
-      <div>
-        <button onClick={showFullNameClick}>Show Full Name</button>
-      </div>
-      <div>Full Name: {fullName}</div>
-    </>
+    <form noValidate onSubmit={handleSubmit}>
+      <p>
+        <label>
+          First name:
+          <input id="firstName" onChange={event => { setFirstNameValue(event.target.value) }} ref={firstNameRef} required />
+        </label>
+      </p>
+      <p>
+        <label>
+          Last name:
+          <input id="lastName" onChange={event => { setLastNameValue(event.target.value) }} ref={lastNameRef} required />
+        </label>
+      </p>
+      <p>
+        <button type="submit">Validate full name</button>
+      </p>
+      <hr />
+      <p>
+        {"Full name: "}
+        <output htmlFor="firstName lastName">{fullName || "incomplete name"}</output>
+      </p>
+    </form>
   );
 };
 

--- a/typing-react-state/Exercise3/solution/src/App.tsx
+++ b/typing-react-state/Exercise3/solution/src/App.tsx
@@ -1,58 +1,69 @@
-// Make changes to the useRefs in order to correct TS errors
-// Take note of the state's structure while adding types.
-// Bonus question - What happens if we use useState
-// instead of useRef?
+/*
 
-import React, { useRef, useState } from "react";
+Exercise:
+
+1) Add types to all of the local state variables.
+2) Fix the type for `previousFullName` so it is mutable.
+
+Bonus question: what happens if we replace useRef with useState?
+
+*/
+
+import React, { FormEvent, useRef, useState } from "react";
 
 const App = () => {
-  const [fullName, setFullName] = useState("");
+  const firstNameRef = useRef<HTMLInputElement>(null);
+  const [firstNameValue, setFirstNameValue] = useState("");
 
-  const firstNameRef = useRef<string | null>();
-  const lastNameRef = useRef({
-    lastName: ""
-  });
+  const lastNameRef = useRef<HTMLInputElement>(null);
+  const [lastNameValue, setLastNameValue] = useState("");
 
-  const handleFirstNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const firstName = e.target.value;
-    firstNameRef.current = firstName
-      ? firstName.charAt(0).toUpperCase() + firstName.slice(1)
-      : null;
-    // Cannot assign to 'current' because it is a read-only property.
-  };
+  const previousFullName = useRef<string | null>();
 
-  const handleLastNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const lastName = e.target.value;
-    lastNameRef.current.lastName = lastName
-      ? lastName.charAt(0).toUpperCase() + lastName.slice(1)
-      : "";
-    // Property 'lastName' does not exist on type '{}'.
-  };
+  const fullName = firstNameValue && lastNameValue ? `${firstNameValue} ${lastNameValue}` : "";
 
-  const showFullNameClick = () => {
-    const fullName =
-      firstNameRef.current && lastNameRef.current.lastName
-        ? `${firstNameRef.current} ${lastNameRef.current.lastName}`
-        : "Incomplete Name";
-    // Property 'lastName' does not exist on type '{}'.
-    setFullName(fullName);
-  };
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+
+    // Give focus to the first input element that isn’t valid
+    if (firstNameRef.current && firstNameRef.current.checkValidity() === false) {
+      firstNameRef.current.focus();
+    } else if (lastNameRef.current && lastNameRef.current.checkValidity() === false) {
+      lastNameRef.current.focus();
+    }
+
+    // Let the user know they’ve updated the full name
+    if (previousFullName.current !== fullName) {
+      if (fullName) {
+        alert(`Update full name from “${previousFullName.current || ""}” to “${fullName}”`);
+      }
+      previousFullName.current = fullName;
+    }
+  }
 
   return (
-    <>
-      <div>
-        First Name:
-        <input onChange={handleFirstNameChange} />
-      </div>
-      <div>
-        Last Name:
-        <input onChange={handleLastNameChange} />
-      </div>
-      <div>
-        <button onClick={showFullNameClick}>Show Full Name</button>
-      </div>
-      <div>Full Name: {fullName}</div>
-    </>
+    <form noValidate onSubmit={handleSubmit}>
+      <p>
+        <label>
+          First name:
+          <input id="firstName" onChange={event => { setFirstNameValue(event.target.value) }} ref={firstNameRef} required />
+        </label>
+      </p>
+      <p>
+        <label>
+          Last name:
+          <input id="lastName" onChange={event => { setLastNameValue(event.target.value) }} ref={lastNameRef} required />
+        </label>
+      </p>
+      <p>
+        <button type="submit">Validate full name</button>
+      </p>
+      <hr />
+      <p>
+        {"Full name: "}
+        <output htmlFor="firstName lastName">{fullName || "incomplete name"}</output>
+      </p>
+    </form>
   );
 };
 


### PR DESCRIPTION
This:

- Rewords the comments to prompt participants to finish the exercise
- Replaces the useRef examples with something more realistic (input refs)
- Refactors all the JSX to use semantic HTML

Exercise:

- [Problem](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/typing-react-state-exercise-3/typing-react-state/Exercise3/problem?file=src/App.tsx)
- [Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/typing-react-state-exercise-3/typing-react-state/Exercise3/solution?file=src/App.tsx)