### PR TITLE
Improve the “Typing React Events” exercise

### DIFF
--- a/typing-react-events/Exercise1/problem/index.html
+++ b/typing-react-events/Exercise1/problem/index.html
@@ -10,6 +10,10 @@
             color-scheme: light dark;
             font-family: system-ui, sans-serif;
         }
+
+        code {
+            font-family: ui-monospace, monospace;
+        }
     </style>
 </head>
 

--- a/typing-react-events/Exercise1/problem/src/App.tsx
+++ b/typing-react-events/Exercise1/problem/src/App.tsx
@@ -1,51 +1,61 @@
-// 1. Add a type to the event argument in the handleFieldChange
-//    function which would allow it to handle the event object 
-//    from both the fields and get rid of the TypeScript error
-// 2. Create an element which will call submitClickHandler 
-//    when the user clicks on this element, while keeping
-//    in mind the type defined for submitClickHandler. 
+/*
 
+Exercise:
 
-import React, { useState, MouseEvent } from 'react';
+1) Fix the `event` argument’s type for `buttonOnClickHandler`.
+2) Add a <button> that can trigger `formOnSubmitHandler`.
+3) Fix the `event` argument’s type for `handleChange`.
+
+*/
+
+import React, { FormEvent, useState } from 'react';
 
 const App = () => {
   const [fields, setFields] = useState({
+    description: "",
     title: "",
-    description: ""
   });
 
-  const handleFieldChange = (e) => {
-    // Parameter 'e' implicitly has an 'any' type.
+  function buttonOnClickHandler(event: never) {
+    alert(`Button received event with type and coordinates: ${event.type} (${event.clientX}, ${event.clientY})`);
+  }
 
-    const { name, value } = e.target;
+  function formOnSubmitHandler(event: FormEvent) {
+    event.preventDefault();
+
+    alert(`Form received event with type: ${event.type}`);
+  }
+
+  function handleChange(event: never) {
     setFields({
       ...fields,
-      [name]: value
+      [event.target.name]: event.target.value
     });
-  };
-
-  const submitClickHandler = (e: MouseEvent<HTMLDivElement>) => {
-    console.log("Submitted!");
-  };
+  }
 
   return (
-    <>
-      <div>
-        Title:
-        <input name="title" onChange={handleFieldChange}/>
-      </div>
-      <div>
-        Description:
-        <div>
-          <textarea name="description" onChange={handleFieldChange}/>
-        </div>
-      </div>
-      <div>
-     
-        {/* Submit element code goes here */}
-       
-      </div>
-    </>
+    <form onSubmit={formOnSubmitHandler}>
+      <p>
+        <label>
+          Title:
+          <input name="title" onChange={handleChange} />
+        </label>
+      </p>
+      <p>
+        <label>
+          Description:
+          <textarea name="description" onChange={handleChange} />
+        </label>
+      </p>
+      <p>
+        <button onClick={buttonOnClickHandler} type="button">
+          Submit (<code>type="button"</code>)
+        </button>
+      </p>
+      <p>
+        {/* Add a button to submit the form here. */}
+      </p>
+    </form>
   );
 }
 

--- a/typing-react-events/Exercise1/solution/index.html
+++ b/typing-react-events/Exercise1/solution/index.html
@@ -10,6 +10,10 @@
             color-scheme: light dark;
             font-family: system-ui, sans-serif;
         }
+
+        code {
+            font-family: ui-monospace, monospace;
+        }
     </style>
 </head>
 

--- a/typing-react-events/Exercise1/solution/src/App.tsx
+++ b/typing-react-events/Exercise1/solution/src/App.tsx
@@ -1,51 +1,63 @@
-// 1. Add a type to the event argument in the handleFieldChange
-//    function which would allow it to handle the event object 
-//    from both the fields and get rid of the TypeScript error
-// 2. Create an element which will call submitClickHandler 
-//    when the user clicks on this element, while keeping
-//    in mind the type defined for submitClickHandler. 
+/*
 
+Exercise:
 
-import React, { useState, MouseEvent, ChangeEvent } from 'react';
+1) Fix the `event` argument’s type for `buttonOnClickHandler`.
+2) Add a <button> that can trigger `formOnSubmitHandler`.
+3) Fix the `event` argument’s type for `handleChange`.
+
+*/
+
+import React, { ChangeEvent, FormEvent, MouseEvent, useState } from 'react';
 
 const App = () => {
   const [fields, setFields] = useState({
+    description: "",
     title: "",
-    description: ""
   });
 
-  const handleFieldChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
+  function buttonOnClickHandler(event: MouseEvent<HTMLButtonElement>) {
+    alert(`Button received event with type and coordinates: ${event.type} (${event.clientX}, ${event.clientY})`);
+  }
+
+  function formOnSubmitHandler(event: FormEvent) {
+    event.preventDefault();
+
+    alert(`Form received event with type: ${event.type}`);
+  }
+
+  function handleChange(event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
     setFields({
       ...fields,
-      [name]: value
+      [event.target.name]: event.target.value
     });
-  };
-
-  const submitClickHandler = (e: MouseEvent<HTMLDivElement>) => {
-    console.log("Submitted!");
-  };
+  }
 
   return (
-    <>
-      <div>
-        Title:
-        <input name="title" onChange={handleFieldChange}/>
-      </div>
-      <div>
-        Description:
-        <div>
-          <textarea name="description" onChange={handleFieldChange}/>
-        </div>
-      </div>
-      <div>
-     
-        <div onClick={submitClickHandler}>
-          Submit
-        </div>
-       
-      </div>
-    </>
+    <form onSubmit={formOnSubmitHandler}>
+      <p>
+        <label>
+          Title:
+          <input name="title" onChange={handleChange} />
+        </label>
+      </p>
+      <p>
+        <label>
+          Description:
+          <textarea name="description" onChange={handleChange} />
+        </label>
+      </p>
+      <p>
+        <button onClick={buttonOnClickHandler} type="button">
+          Submit (<code>type="button"</code>)
+        </button>
+      </p>
+      <p>
+        <button type="submit">
+          Submit (<code>type="submit"</code>)
+        </button>
+      </p>
+    </form>
   );
 }
 


### PR DESCRIPTION
This:

- Rewords the comments to prompt participants to finish the exercise
- Refactors the JSX to use semantic HTML

I used `FormEvent` and I’m not sure if that means we should also cover this during the training.


**Exercise**

- [Problem](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/typing-react-events-exercise/typing-react-events/Exercise1/problem?file=src/App.tsx)
- [Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/typing-react-events-exercise/typing-react-events/Exercise1/solution?file=src/App.tsx)
