### PR TITLE
Improve the styles for the “React Utility Types” exercise

### DIFF
--- a/react-utility-types/Exercise1/problem/index.html
+++ b/react-utility-types/Exercise1/problem/index.html
@@ -3,11 +3,10 @@
 
 <head>
     <meta charset="utf-8" />
-    <title>React Utility Types</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Utility Types</title>
     <style>
         html {
-            color-scheme: light dark;
             font-family: system-ui, sans-serif;
         }
     </style>

--- a/react-utility-types/Exercise1/problem/src/App.tsx
+++ b/react-utility-types/Exercise1/problem/src/App.tsx
@@ -11,25 +11,18 @@ import React from "react";
 
 type CustomElementProps<T extends React.ElementType> = {
   as?: T,
-} & React.AnchorHTMLAttributes<HTMLDivElement>
-// Do you recall a similar “bad type” from earlier?
+} & React.AnchorHTMLAttributes<HTMLDivElement>;
 
 const CustomParent = ({
-  message,
-  // Binding element 'message' implicitly has an 'any' type.
-
   backgroundColor,
-  // Binding element 'backgroundColor' implicitly has an 'any' type.
-
+  header,
   children
-  // Binding element 'children' implicitly has an 'any' type.
-
 }) => {
   return (
-    <p style={{ backgroundColor }}>
-      <h4>{message}</h4>
+    <section style={{ backgroundColor }}>
+      <h2>{header}</h2>
       {children}
-    </p>
+    </section>
   );
 };
 
@@ -38,7 +31,7 @@ const CustomElement = <T extends React.ElementType>({
   children,
   ...restOfProps }: CustomElementProps<T>
 ) => {
-  const Component = as || "div";
+  const Component = as || "p";
 
   return (
     <Component {...restOfProps}>
@@ -49,11 +42,23 @@ const CustomElement = <T extends React.ElementType>({
 
 const App = () => {
   return (
-    <CustomParent message="Hi there!" backgroundColor="red">
-      <CustomElement as="button" href="www.google.com">
-        What element am I?
-      </CustomElement>
-    </CustomParent>
+    <>
+      <h1>React Utility Types</h1>
+
+      <CustomParent backgroundColor="lightblue" header="Anchor element">
+        {/* This should NOT error. */}
+        <CustomElement as="a" href="https://www.bitovi.com">
+          Bitovi
+        </CustomElement>
+      </CustomParent>
+
+      <CustomParent backgroundColor="pink" header="Button element">
+        {/* This SHOULD error. */}
+        <CustomElement as="button" href="https://www.bitovi.com">
+          Bitovi
+        </CustomElement>
+      </CustomParent>
+    </>
   );
 }
 

--- a/react-utility-types/Exercise1/solution/index.html
+++ b/react-utility-types/Exercise1/solution/index.html
@@ -3,11 +3,10 @@
 
 <head>
     <meta charset="utf-8" />
-    <title>React Utility Types</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Utility Types</title>
     <style>
         html {
-            color-scheme: light dark;
             font-family: system-ui, sans-serif;
         }
     </style>

--- a/react-utility-types/Exercise1/solution/src/App.tsx
+++ b/react-utility-types/Exercise1/solution/src/App.tsx
@@ -7,11 +7,11 @@
 //    Using other attributes like "href" as a prop should throw
 //    an error.
 
-import React, { PropsWithChildren, ComponentPropsWithoutRef } from "react";
+import React, { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
 interface CustomParentType {
-  message: string;
   backgroundColor: string;
+  header: string;
 }
 
 type CustomElementProps<T extends React.ElementType> = {
@@ -19,15 +19,15 @@ type CustomElementProps<T extends React.ElementType> = {
 } & ComponentPropsWithoutRef<T>;
 
 const CustomParent = ({
-  message,
   backgroundColor,
+  header,
   children
 }: PropsWithChildren<CustomParentType>) => {
   return (
-    <p style={{ backgroundColor }}>
-      <h4>{message}</h4>
+    <section style={{ backgroundColor }}>
+      <h2>{header}</h2>
       {children}
-    </p>
+    </section>
   );
 };
 
@@ -36,28 +36,30 @@ const CustomElement = <T extends React.ElementType>({
   children,
   ...restOfProps
 }: CustomElementProps<T>) => {
-  const Component = as || "div";
+  const Component = as || "p";
 
   return <Component {...restOfProps}>{children}</Component>;
 };
 
 const App = () => {
   return (
-    <CustomParent message="This is a button" backgroundColor="red">
-      <CustomElement as="button" href="www.google.com">
-      {/* Type '{ children: string; as: "button"; href: string; }' 
-      is not assignable to type 'IntrinsicAttributes & 
-      { as?: "button" | undefined; } & 
-      Omit<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, 
-      HTMLButtonElement>, "ref">'.
-      
-      Property 'href' does not exist on type 'IntrinsicAttributes 
-      & { as?: "button" | undefined; } & 
-      Omit<DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, 
-      HTMLButtonElement>, "ref">'. */}
-        What element am I?
-      </CustomElement>
-    </CustomParent>
+    <>
+      <h1>React Utility Types</h1>
+
+      <CustomParent backgroundColor="lightblue" header="Anchor element">
+        {/* This should NOT error. */}
+        <CustomElement as="a" href="https://www.bitovi.com">
+          Bitovi
+        </CustomElement>
+      </CustomParent>
+
+      <CustomParent backgroundColor="pink" header="Button element">
+        {/* This SHOULD error. */}
+        <CustomElement as="button" href="https://www.bitovi.com">
+          Bitovi
+        </CustomElement>
+      </CustomParent>
+    </>
   );
 };
 


### PR DESCRIPTION
This:

- Adds multiple examples in the code so it’s easier to have a good vs. bad example
- Changes the background colors so the text is easier to read
- Fixes the html by not having an `h4` in a `p`


**Exercise**

- [Problem](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/react-utility-types-exercise/react-utility-types/Exercise1/problem?file=src/App.tsx)
- [Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/react-utility-types-exercise/react-utility-types/Exercise1/solution?file=src/App.tsx)
