### PR TITLE
Format the “Unit Testing React” links as markdown

### DIFF
--- a/unit-testing-react-what-why-how/README.md
+++ b/unit-testing-react-what-why-how/README.md
@@ -1,51 +1,41 @@
-## Exercises
+# Exercises
 
 1. Basics-together (live-code walkthrough)
-
-- Problem: https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Basics-together/problem?file=/src/index.test.ts
-- Solution: https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Basics-together/solution?file=/src/index.test.ts
+    - [Problem](https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Basics-together/problem?file=/src/index.test.ts)
+    - [Solution](https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Basics-together/solution?file=/src/index.test.ts)
 
 2. Basics (solo exercise)
+    - [Problem](https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Basics/problem?file=/src/index.test.ts)
+    - [Solution](https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Basics/solution?file=/src/index.test.ts)
 
-- Problem: https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Basics/problem?file=/src/index.test.ts
-- Solution: https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Basics/solution?file=/src/index.test.ts
+3. Simplify Rock Paper Scissors (live-code walkthrough)
+    - [Problem](https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Simplify-rock-paper-scissors/problem?file=/src/RockPaperScissors.tsx)
+    - [Solution](https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Simplify-rock-paper-scissors/solution?file=/src/RockPaperScissors.tsx)
 
-3. Simplify Rock Paper Scissors (live code walkthrough)
+4. Test Rock Paper Scissors (live-code walkthrough)
+    - [Problem](https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/test-rock-paper-scissors/problem?file=/src/RockPaperScissors.test.tsx)
+    - [Solution](https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/test-rock-paper-scissors/solution?file=/src/RockPaperScissors.test.tsx)
 
-- Problem: https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Simplify-rock-paper-scissors/problem?file=/src/RockPaperScissors.tsx
-- Solution: https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Simplify-rock-paper-scissors/solution?file=/src/RockPaperScissors.tsx
-
-4. Test Rock Paper Scissors (live code walkthrough)
-
-- Problem: https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/test-rock-paper-scissors/problem?file=/src/RockPaperScissors.test.tsx
-- Solution: https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/test-rock-paper-scissors/solution?file=/src/RockPaperScissors.test.tsx
-
-5. Button (solo )
-
-- Problem: https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Button/problem?file=/src/App.test.tsx
-- Solution: https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Button/solution?file=/src/App.test.tsx
+5. Button (solo)
+    - [Problem](https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Button/problem?file=/src/App.test.tsx)
+    - [Solution](https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/Button/solution?file=/src/App.test.tsx)
 
 6. renderHook (live-code walkthrough)
-
-- Problem: https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/renderHook/problem?file=/src/index.test.js
-- Solution: https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/renderHook/solution?file=/src/index.test.js
+    - [Problem](https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/renderHook/problem?file=/src/index.test.js)
+    - [Solution](https://codesandbox.io/s/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/renderHook/solution?file=/src/index.test.js)
 
 ## Code used in slides as screenshots & code snippets
 
 > codesandbox isn't needed for these in presentation, just provided in case someone wants to play with it.
 
-getStringLength:
-
-- https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/getStringLength
+    - [getStringLength](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/getStringLength)
 
 ## Code that may be used at some point in the future
 
 buildDropdownList:
-
-- problem https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/buildDropdownList/problem
-- solution: https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/buildDropdownList/solution
+    - [Problem](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/buildDropdownList/problem)
+    - [Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/unit-testing-react-what-why-how/buildDropdownList/solution)
 
 vehicle-selector-react: uses an app built for another react training that may be of interest.
-
-- Repo: https://github.com/bitovi/vehicle-selector-react
-- Demo: https://bitovi.github.io/vehicle-selector-react/
+    - [Repo](https://github.com/bitovi/vehicle-selector-react)
+    - [Demo](https://bitovi.github.io/vehicle-selector-react/)


### PR DESCRIPTION
This fixes the indentation so it’s easier to copy & paste the links when sharing to something like Notion.