### PR TITLE
Add @axe-core/react to the “Incorporating Accessibility” demo

### DIFF
--- a/incorporating-accessibility-into-your-dev-process/demo/package-lock.json
+++ b/incorporating-accessibility-into-your-dev-process/demo/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@axe-core/react": "^4.8.1",
         "@babel/preset-env": "^7.23.2",
         "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.2",
@@ -61,6 +62,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@axe-core/react": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.8.1.tgz",
+      "integrity": "sha512-55eSebGFYQaBRJsACCr+SxX9QV7buSmQUnUMH37y0k2CvlyPAuPLNcG6IcSaU+U6IhDJ5EWSHBIoM4HSVU3f3w==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "~4.8.2",
+        "requestidlecallback": "^0.3.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4150,7 +4161,6 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",
       "integrity": "sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -9568,6 +9578,12 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "dev": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10601,6 +10617,16 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@axe-core/react": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.8.1.tgz",
+      "integrity": "sha512-55eSebGFYQaBRJsACCr+SxX9QV7buSmQUnUMH37y0k2CvlyPAuPLNcG6IcSaU+U6IhDJ5EWSHBIoM4HSVU3f3w==",
+      "dev": true,
+      "requires": {
+        "axe-core": "~4.8.2",
+        "requestidlecallback": "^0.3.0"
       }
     },
     "@babel/code-frame": {
@@ -13447,8 +13473,7 @@
       "version": "4.8.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",
       "integrity": "sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "axe-result-pretty-print": {
       "version": "1.0.2",
@@ -17423,6 +17448,12 @@
           "dev": true
         }
       }
+    },
+    "requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",

--- a/incorporating-accessibility-into-your-dev-process/demo/package.json
+++ b/incorporating-accessibility-into-your-dev-process/demo/package.json
@@ -11,6 +11,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@axe-core/react": "^4.8.1",
     "@babel/preset-env": "^7.23.2",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.2",

--- a/incorporating-accessibility-into-your-dev-process/demo/src/index.tsx
+++ b/incorporating-accessibility-into-your-dev-process/demo/src/index.tsx
@@ -1,5 +1,6 @@
+import axe from "@axe-core/react";
 import React from "react";
-import { createRoot } from "react-dom/client";
+import ReactDOM, { createRoot } from "react-dom/client";
 
 import App from "./App";
 
@@ -7,6 +8,7 @@ const mainElement = document.querySelector("main");
 if (mainElement) {
     const root = createRoot(mainElement);
     root.render(<App />);
+    axe(React, ReactDOM, 1000);
 } else {
     console.error("No main element");
 }


### PR DESCRIPTION
This allows developers to see axe issues when they open up their browser’s DevTools.

Demo: https://codesandbox.io/s/github/bitovi/trainings/tree/axe-core-react/incorporating-accessibility-into-your-dev-process/demo

<img width="959" alt="Screenshot of axe-core react’s report on the demo page" src="https://github.com/bitovi/trainings/assets/10070176/5a38a0be-a6ad-4ed1-b952-234e8b3f0897">
