### PR TITLE
Fix the Lighthouse RegEx in the “Incorporating Accessibility” demo

### DIFF
--- a/incorporating-accessibility-into-your-dev-process/demo/lighthouse.mjs
+++ b/incorporating-accessibility-into-your-dev-process/demo/lighthouse.mjs
@@ -23,7 +23,7 @@ try {
 }
 
 function extractLocalhostUrl(data) {
-    const match = data.match(/Local:   (http:\/\/localhost:\d+\/)/);
+    const match = data.match(/Local:\s*([\w-]+:\/\/[\w-.]+:\d+\/)/);
     return match && match[1];
 }
 


### PR DESCRIPTION
Now it can match against not only `localhost` but also urls like `http://127.0.0.1:4174/`.