### PR TITLE
Improve how the “Practical React Unit Testing with Jest Mocks and Spies” README is formatted

### DIFF
--- a/practical-react-unit-testing-with-jest-mocks-and-spies/README.md
+++ b/practical-react-unit-testing-with-jest-mocks-and-spies/README.md
@@ -1,39 +1,37 @@
-# Code Sandbox links
-
-**Exercises**
+# Exercises
 
 Manual Mocking
 
-[Exercise](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise1/problem?file=src/Select.test.tsx)
+- [Problem](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise1/problem?file=src/Select.test.tsx)
 
-[Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise1/solution?file=src/Select.test.tsx)
+- [Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise1/solution?file=src/Select.test.tsx)
 
 Mocking API calls and fetch
 
-[Exercise](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise2/problem?file=/src/endpoints/get-data.test.ts)
+- [Problem](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise2/problem?file=/src/endpoints/get-data.test.ts)
 
-[Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise2/solution?file=/src/endpoints/get-data.test.ts)
+- [Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise2/solution?file=/src/endpoints/get-data.test.ts)
 
 Mocking with mock files
 
-[Exercise](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise3/problem?file=/src/toSelectOptions.test.tsx)
+- [Problem](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise3/problem?file=/src/toSelectOptions.test.tsx)
 
-[Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise3/solution?file=/src/toSelectOptions.test.tsx)
+- [Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise3/solution?file=/src/toSelectOptions.test.tsx)
 
 Spies
 
-[Exercise](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise4/problem?file=/src/VideoPlayer.test.ts)
+- [Problem](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise4/problem?file=/src/VideoPlayer.test.ts)
 
-[Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise4/solution?file=/src/VideoPlayer.test.ts)
+- [Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise4/solution?file=/src/VideoPlayer.test.ts)
 
 Automatic class mocks
 
-[Exercise](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise5/problem?file=/src/Vehicle.test.ts)
+- [Problem](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise5/problem?file=/src/Vehicle.test.ts)
 
-[Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise5/solution?file=/src/Vehicle.test.ts)
+- [Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise5/solution?file=/src/Vehicle.test.ts)
 
 Mocking React contexts
 
-[Exercise](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise6/problem?file=/src/useYears.test.ts)
+- [Problem](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise6/problem?file=/src/useYears.test.ts)
 
-[Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise6/solution?file=/src/useYears.test.ts)
+- [Solution](https://codesandbox.io/p/sandbox/github/bitovi/trainings/tree/main/practical-react-unit-testing-with-jest-mocks-and-spies/Exercise6/solution?file=/src/useYears.test.ts)


### PR DESCRIPTION
Changing the text from “Exercise” to “Problem” makes it clearer and consistent with the other README files.